### PR TITLE
Add Arduino.h for digitalWrite

### DIFF
--- a/esphome/components/emporia_vue_utility/emporia_vue_utility.h
+++ b/esphome/components/emporia_vue_utility/emporia_vue_utility.h
@@ -3,6 +3,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
+#include <Arduino.h>
 
 // If the instant watts being consumed meter reading is outside of these ranges,
 // the sample will be ignored which helps prevent garbage data from polluting


### PR DESCRIPTION
On my esphome 2024.5.5, it complains about missing definition of `byte` and `digitalWrite`. Looks like those are defined in `Arduino.h`.