### PR TITLE
Add polling_enabled option for wall-clock aligned polling

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -18,7 +18,7 @@ The example YAMLs should work out of the box, provided you fill in the necessary
 
 ### Sensors
 
-This Vue sensor component provides **6** output values and takes **3** configuration options.
+This Vue sensor component provides **6** output values and takes **4** configuration options.
 
 A full configuration can look like this:
 
@@ -36,6 +36,7 @@ sensor:
     uart_id: emporia_uart
     debug: true
     update_interval: 15s
+    polling_enabled: true
     power:
       name: '${name} Watts'
     power_export:
@@ -89,6 +90,36 @@ sensor:
   - platform: emporia_vue_utility
     update_interval: 15s
     ...
+```
+
+#### Disabling the built-in polling timer
+
+By default, the component uses ESPHome's `PollingComponent` timer to request meter readings at the `update_interval` rate. The built-in timer starts when the device boots, so readings land at arbitrary times relative to the clock.
+
+If you monitor power from multiple systems — inverters, utility meters, CTs, etc. — their readings will each arrive at different offsets, making it harder to get a coherent snapshot of live power flow at any given moment. By polling all of them on wall-clock boundaries (e.g. `:00`, `:10`, `:20`, ...) you can loosely align their readings so that values arriving in the same window actually represent the same approximate time.
+
+To do this, disable the built-in timer with `polling_enabled: false` and use ESPHome's `on_time` to trigger `component.update` on a cron schedule instead. This requires a time source — either the [Home Assistant time component](https://esphome.io/components/time/homeassistant) or [SNTP](https://esphome.io/components/time/sntp) — so the device knows what wall-clock time it is.
+
+When disabled, the component calls `stop_poller()` at startup so the internal timer never fires. The `update()` method still works normally, so you can trigger it externally via `component.update`.
+
+Note that `update_interval` must still be set to a reasonable value (under 40 seconds) even when `polling_enabled` is `false`, because the component uses `update_interval / 4` internally for duplicate reading detection. Setting it too high can cause readings to be silently rejected.
+
+Example using `on_time` for wall-clock aligned 10-second polling:
+
+```yaml
+sensor:
+  - platform: emporia_vue_utility
+    id: vue_sensor
+    polling_enabled: false
+    update_interval: 11s
+    ...
+
+time:
+  - platform: homeassistant
+    on_time:
+      - seconds: /10
+        then:
+          - component.update: vue_sensor
 ```
 
 #### Debug logs

--- a/esphome/components/emporia_vue_utility/emporia_vue_utility.cpp
+++ b/esphome/components/emporia_vue_utility/emporia_vue_utility.cpp
@@ -14,6 +14,9 @@ void EmporiaVueUtility::setup() {
   led_wifi(false);
   clear_serial_input();
   send_loglevel(debug_ ? 20 : 10); // Enables MGM111's debug logs as well.
+  if (!polling_enabled_) {
+    stop_poller();
+  }
 }
 
 void EmporiaVueUtility::update() {

--- a/esphome/components/emporia_vue_utility/emporia_vue_utility.h
+++ b/esphome/components/emporia_vue_utility/emporia_vue_utility.h
@@ -148,6 +148,7 @@ class EmporiaVueUtility : public PollingComponent, public uart::UARTDevice {
   uint16_t cost_unit = 0;
 
   void set_debug(bool enable) { debug_ = enable; }
+  void set_polling_enabled(bool enable) { polling_enabled_ = enable; }
   void set_update_interval(uint32_t update_interval) {
     PollingComponent::set_update_interval(update_interval);
     update_interval_ = std::chrono::milliseconds(update_interval);
@@ -837,6 +838,7 @@ class EmporiaVueUtility : public PollingComponent, public uart::UARTDevice {
 
  private:
   bool debug_ = false;
+  bool polling_enabled_ = true;
   steady_clock::duration update_interval_;
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *power_export_sensor_{nullptr};

--- a/esphome/components/emporia_vue_utility/sensor.py
+++ b/esphome/components/emporia_vue_utility/sensor.py
@@ -58,6 +58,7 @@ CONFIG_SCHEMA = cv.All(
                 for name in ENERGY_SENSOR_TYPES
             },
             cv.Optional(CONF_DEBUG, default=False): cv.boolean,
+            cv.Optional("polling_enabled", default=True): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("30s"))
@@ -77,3 +78,5 @@ async def to_code(config):
 
     if CONF_DEBUG in config:
         cg.add(var.set_debug(config[CONF_DEBUG]))
+
+    cg.add(var.set_polling_enabled(config["polling_enabled"]))


### PR DESCRIPTION
## Summary

Adds a `polling_enabled` config option (default: `true`) that lets users disable
the built-in `PollingComponent` timer. This allows driving meter requests
externally via `component.update` -- for example, using ESPHome's `on_time` to
poll on wall-clock boundaries (`:00`, `:10`, `:20`, ...).

### Why?

If you monitor power from multiple systems (inverters, utility meters, CTs),
their readings each arrive at arbitrary offsets from boot time. Aligning them to
wall-clock boundaries gives a more coherent snapshot of live power flow.

### Implementation

- When `polling_enabled: false`, `setup()` calls `stop_poller()` to kill the
  internal timer
- `update()` is unchanged -- works normally when triggered by `on_time` via
  `component.update`
- `update_interval` must still be set under 40s (used internally for duplicate
  reading detection)
- Defaults to `true` -- fully backward compatible, no behavior change for
  existing configs

### Changes

- `emporia_vue_utility.h` -- `polling_enabled_` field + setter
- `emporia_vue_utility.cpp` -- `stop_poller()` in `setup()`
- `sensor.py` -- config option wiring
- `docs/yaml.md` -- new section documenting the option with usage example
